### PR TITLE
Add simplified docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.8.0 as builder
+FROM node:9.8.0-alpine as builder
 ARG GMAPS_API_KEY
 
 WORKDIR oldto-site

--- a/README.md
+++ b/README.md
@@ -18,7 +18,27 @@ for popular locations like the CN Tower or City Hall.
 
 * Live site: https://oldtoronto.sidewalklabs.com
 
-## Development setup
+## :computer: Local Development
+
+If you're willing to install docker, it is usually the simplest way to
+get up and running.
+
+### Docker
+
+**Docker** is a tool that helps isolate your development environment.
+
+**Requirements:**
+- Docker (tested on v17.10.0)
+- Docker Compose (tested in v1.16.1)
+
+```
+$ cd path/to/oldto
+$ docker-compose up
+```
+
+You may now view the webapp at: [`localhost:5000`][http://localhost:5000]
+
+### Manually
 
 Setup dependencies (on a Mac):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  webapp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+     - "5000:80"

--- a/nginx.config
+++ b/nginx.config
@@ -13,6 +13,6 @@ server {
 
     # proxy the /api to connect to the API server:
     location /api {
-        proxy_pass  http://swl-api-server-web:8000;
+        proxy_pass  http://api.sidewalklabs.com;
     }
 }


### PR DESCRIPTION
Hi! not sure if this aligns with your vision, but just wanted to put it forward, since the dockerfile has a few bumps as-is.

- api was proxied in nginx to a host that didn't exist in dockerland
- alpine linux is waaaaay smaller, to better for local testing when people don't have fast connections available.
- added docker-compose support

I'm not often a docker user, but given all the ways this repo is used -- api, frontend, processing -- thought it might be helpful :)